### PR TITLE
license and bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can use the command `muddlit: Build with muddy` to compile your project.
 
 ## License
 
-`muddlit` is released into the public domain under the [0BSD](LICENSE.txt).
+`muddlit` is released under the [0BSD](LICENSE.txt).
 
 This package includes or depends on third-party components under their own
 licenses:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,12 @@
 import uglify from "@gesslar/uglier"
 
 export default [
+  {ignores: ["src/extension.mjs"]},
   ...uglify({
     with: [
-      "lints-js", // default files: ["**/*.{js,mjs,cjs}"]
-      "lints-jsdoc", // default files: ["**/*.{js,mjs,cjs}"]
-      "node", // default files: ["**/*.{js,mjs,cjs}"]
+      "lints-js", // default files: ["src/**/*.{js,mjs,cjs}"]
+      "lints-jsdoc", // default files: ["src/**/*.{js,mjs,cjs}"]
+      "node", // default files: ["src/**/*.{js,mjs,cjs}"]
       "vscode-extension", // default files: ["src/**/*.{js,mjs,cjs}"]
     ],
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muddlit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muddlit",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/toolkit": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint src/ --fix",
     "update": "npx npm-check-updates -u && npm install",
     "pr": "gt submit -p --ai",
-    "package": "npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
+    "package": "node scripts/clean-vsix.js && npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
     "publish:vsce": "npm run package && npx @vscode/vsce publish --packagePath vsix/*.vsix --pat $VSX_MARKETPLACE_ACCESS_TOKEN",
     "publish:ovsx": "npm run package && npx ovsx publish --packagePath vsix/*.vsix --pat $OVSX_ACCESS_TOKEN",
     "patch": "npm version patch",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "muddlit",
   "displayName": "muddlit",
   "description": "A VS Code extension for users of @gesslar/muddy.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "gesslar",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint src/ --fix",
     "update": "npx npm-check-updates -u && npm install",
     "pr": "gt submit -p --ai",
-    "package": "node scripts/clean-vsix.js && npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
+    "package": "node scripts/assure-clean-vsix-directory.js && npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
     "publish:vsce": "npm run package && npx @vscode/vsce publish --packagePath vsix/*.vsix --pat $VSX_MARKETPLACE_ACCESS_TOKEN",
     "publish:ovsx": "npm run package && npx ovsx publish --packagePath vsix/*.vsix --pat $OVSX_ACCESS_TOKEN",
     "patch": "npm version patch",

--- a/scripts/assure-clean-vsix-directory.js
+++ b/scripts/assure-clean-vsix-directory.js
@@ -21,7 +21,7 @@ try {
     const stats = statSync(dir)
 
     if(!stats.isDirectory()) {
-      console.error(`'${dir} is not a directory.`)
+      console.error(`'${dir}' is not a directory.`)
       process.exit(1)
     }
   } else {

--- a/scripts/assure-clean-vsix-directory.js
+++ b/scripts/assure-clean-vsix-directory.js
@@ -11,10 +11,26 @@
  * If [dir] is omitted, defaults to "vsix/" relative to cwd.
  */
 
-import {readdirSync, unlinkSync} from "node:fs"
+import {existsSync, mkdirSync, readdirSync, statSync, unlinkSync} from "node:fs"
 import {join, resolve} from "node:path"
 
 const dir = resolve(process.argv[2] || "vsix")
+
+try {
+  if(existsSync(dir)) {
+    const stats = statSync(dir)
+
+    if(!stats.isDirectory()) {
+      console.error(`'${dir} is not a directory.`)
+      process.exit(1)
+    }
+  } else {
+    mkdirSync(dir)
+  }
+} catch {
+  process.exit(0)
+}
+
 
 const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
 

--- a/scripts/assure-clean-vsix-directory.js
+++ b/scripts/assure-clean-vsix-directory.js
@@ -28,7 +28,7 @@ try {
     mkdirSync(dir)
   }
 } catch {
-  process.exit(0)
+  process.exit(1)
 }
 
 

--- a/scripts/assure-clean-vsix-directory.js
+++ b/scripts/assure-clean-vsix-directory.js
@@ -31,7 +31,6 @@ try {
   process.exit(1)
 }
 
-
 const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
 
 for(const file of vsixFiles) {

--- a/scripts/clean-vsix.js
+++ b/scripts/clean-vsix.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/**
+ * Removes all .vsix files from a target directory. Intended as a pre-build
+ * step so publish commands that glob the directory only pick up the freshly
+ * built package.
+ *
+ * Usage:
+ *   node scripts/clean-vsix.js [dir]
+ *
+ * If [dir] is omitted, defaults to "vsix/" relative to cwd.
+ */
+
+import {readdirSync, unlinkSync} from "node:fs"
+import {join, resolve} from "node:path"
+
+const dir = resolve(process.argv[2] || "vsix")
+
+const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
+
+for(const file of vsixFiles) {
+  console.log(`Removing ${file}`)
+  unlinkSync(join(dir, file))
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds license metadata to `package.json` and `README.md`, introduces a `vsix/.keep` file to track the output directory in git, and adds a new `scripts/assure-clean-vsix-directory.js` pre-build script that purges stale `.vsix` artefacts before packaging.

- `package.json`: `"license": "0BSD"` field added; `--skip-license` flag appended to the `package` script (skips generating a third-party notices file inside the VSIX — intentional given the manual dependency table in `README.md`)
- `README.md`: New License section with a dependency attribution table (`@gesslar/toolkit` → 0BSD, `ps-list` → MIT)
- `scripts/assure-clean-vsix-directory.js`: New utility that resolves the target directory, creates it if absent, and deletes any existing `.vsix` files before packaging
- `vsix/.keep`: Empty sentinel file so the output directory is tracked in git while `*.vsix` files remain in `.gitignore`
- `package-lock.json`: Lock-file updated to reflect the version bump and any transitive dependency changes

<h3>Confidence Score: 5/5</h3>

Safe to merge — licence metadata, dependency bump, and a straightforward pre-build script with no functional risk.

All changes are additive and low-risk: adding a licence field, a README attribution table, an empty `.keep` file, and a small Node.js utility script. The only finding is a P2 style suggestion (surfacing the error message in the catch block) that does not affect correctness or the happy path.

No files require special attention.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fassure-clean-vsix-directory.js%3A30-32%0A**Silent%20catch%20makes%20failures%20hard%20to%20diagnose**%0A%0AIf%20%60mkdirSync%60%20%28or%20%60statSync%60%29%20throws%20%E2%80%94%20e.g.%20due%20to%20a%20permission%20error%20%E2%80%94%20the%20process%20exits%20with%20code%201%20but%20prints%20nothing.%20The%20caller%20%28%60npm%20run%20package%60%29%20will%20just%20silently%20fail%20its%20pre-build%20step%2C%20which%20can%20be%20confusing%20to%20debug.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%28err%29%20%7B%0A%20%20%20%20console.error%28%60Failed%20to%20prepare%20directory%20'%24%7Bdir%7D'%3A%20%24%7Berr.message%7D%60%29%0A%20%20%20%20process.exit%281%29%0A%20%20%7D%0A%60%60%60%0A%0A&repo=gesslar%2Fmuddlit"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["bump"](https://github.com/gesslar/muddlit/commit/3453691e64e863fabde9325a82f73439c30db050) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28047448)</sub>

<!-- /greptile_comment -->