### PR TITLE
04 10 maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
       },
       "devDependencies": {
         "@gesslar/uglier": "^2.4.0",
-        "@types/node": "^25.5.2",
-        "@types/vscode": "^1.110.0",
+        "@types/node": "^25.6.0",
+        "@types/vscode": "^1.115.0",
         "esbuild": "^0.28.0",
         "eslint": "^10.2.0"
       },
       "engines": {
         "node": ">=24.11.0",
-        "vscode": "^1.110.0"
+        "vscode": "^1.115.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -838,19 +838,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
+      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2339,9 +2339,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "prepackage": "node scripts/assure-clean-vsix-directory.js",
     "package": "npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
     "prepublish": "npm run package",
-    "publish:vsce": "npx @vscode/vsce publish --packagePath vsix/*.vsix --pat $VSX_MARKETPLACE_ACCESS_TOKEN",
-    "publish:ovsx": "npx ovsx publish --packagePath vsix/*.vsix --pat $OVSX_ACCESS_TOKEN",
+    "publish:vsce": "npm run prepublish && npx @vscode/vsce publish --packagePath vsix/*.vsix --pat $VSX_MARKETPLACE_ACCESS_TOKEN",
+    "publish:ovsx": "npm run prepublish && npx ovsx publish --packagePath vsix/*.vsix --pat $OVSX_ACCESS_TOKEN",
     "patch": "npm version patch",
     "minor": "npm version minor",
     "major": "npm version major"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/gesslar/muddlit"
   },
   "engines": {
-    "vscode": "^1.110.0",
+    "vscode": "^1.115.0",
     "node": ">=24.11.0"
   },
   "categories": [
@@ -56,8 +56,8 @@
   },
   "devDependencies": {
     "@gesslar/uglier": "^2.4.0",
-    "@types/node": "^25.5.2",
-    "@types/vscode": "^1.110.0",
+    "@types/node": "^25.6.0",
+    "@types/vscode": "^1.115.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.2.0"
   },


### PR DESCRIPTION
- **maintenance**
- **04-10-maintenance: 2026-04-10 22:43 - quick save**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a routine maintenance PR that updates dependencies in `package.json` and regenerates `package-lock.json`. The main changes involve bumping `@gesslar/uglier` to `^2.4.0`, `@types/node` to `^25.6.0`, and `eslint` to `^10.2.0`, along with their transitive dependency tree (including `@astrojs/compiler` 3.0.1 via `eslint-plugin-astro`).

- Updated `@gesslar/uglier` from `^2.3.x` to `^2.4.0` (a dev-only linting/formatting tool)
- Updated `@types/node` to `^25.6.0` and `eslint` to `^10.2.0`
- Bumped all transitive dependencies accordingly in `package-lock.json`
- **Minor engine mismatch introduced**: `@gesslar/uglier@2.4.0` now requires `node >=24.13.0`, but `package.json` still declares `\"node\": \">=24.11.0\"` — a developer on Node 24.11.x or 24.12.x may encounter engine warnings during `npm install`

<h3>Confidence Score: 4/5</h3>

Safe to merge; the Node engine version mismatch is a minor dev-environment inconvenience, not a production concern.

This is a straightforward dependency update PR. The only concrete issue is the `engines.node` field (24.11.0) being lower than what `@gesslar/uglier@2.4.0` requires (24.13.0). This only affects developers who are on a slightly older Node 24 patch and run `npm install` — it will not affect end users of the extension. A one-line fix to bump the minimum to 24.13.0 would resolve it entirely.

`package.json` — the `engines.node` minimum should be updated to `>=24.13.0` to match the dev dependency requirement.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage.json%3A13%0A**Node%20engine%20minimum%20version%20too%20low%20for%20dev%20dependency**%0A%0A%60package.json%60%20declares%20%60%22node%22%3A%20%22%3E%3D24.11.0%22%60%2C%20but%20%60%40gesslar%2Fuglier%402.4.0%60%20%28a%20dev%20dependency%20resolved%20in%20this%20PR%29%20requires%20%60%22node%22%3A%20%22%3E%3D24.13.0%22%60%20%28see%20%60package-lock.json%60%20line%20658%29.%20A%20developer%20running%20Node%2024.11.x%20or%2024.12.x%20will%20see%20engine-incompatibility%20warnings%20during%20%60npm%20install%60%20and%20may%20encounter%20issues%20running%20the%20linter.%0A%0AConsider%20bumping%20the%20engine%20minimum%20to%20match%20the%20most%20restrictive%20dev%20dependency%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%22node%22%3A%20%22%3E%3D24.13.0%22%0A%60%60%60%0A%0A&repo=gesslar%2Fmuddlit"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["04-10-maintenance: 2026-04-10 22:43 - qu..."](https://github.com/gesslar/muddlit/commit/6f80881c6704301bd68b1bffee56b688eb820ac0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28070062)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->