### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   Build:
@@ -30,7 +30,6 @@ jobs:
     uses: gesslar/Maint/.github/workflows/ReleaseOnly.yaml@main
     secrets: inherit
     with:
-      quality_check: "Quality"
-      artefacts: '["vsix"]'
+      artefacts: "[\"vsix\"]"
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes minor housekeeping updates to the `Release.yaml` workflow. The changes are:

- **Whitespace formatting**: Adds spaces inside brackets for `types: [ closed ]` and `branches: [ main ]` — purely cosmetic.
- **`quality_check` input removed**: The `quality_check: "Quality"` parameter was removed from the `ReleaseOnly.yaml` call (discussed in a prior thread).
- **`artefacts` quoting style**: Changed from single-quoted YAML (`'["vsix"]'`) to double-quoted YAML (`"[\"vsix\"]"`), which produces the exact same string at runtime — no functional difference.
- **Reusable workflow reference**: The `ReleaseOnly.yaml@main` reference correctly targets `@main` as required by project conventions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are cosmetic or already-discussed parameter removals with no new logic introduced.

The only substantive change (removal of `quality_check`) was already raised in a prior review thread. The remaining changes are whitespace formatting and an equivalent YAML quoting style swap — neither affects runtime behaviour. The `@main` pin is correctly in place per project policy.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["update workflow"](https://github.com/gesslar/muddlit/commit/a5a26e96475a3fd08b20cb37a48ffd57aae28083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28734131)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->